### PR TITLE
ARM Ubuntu Glibc

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
           name: linux-x86-natives
           path: src/main/resources/natives/*
   linux-arm-natives:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Downgrades ARM Ubuntu runner to glibc 2.27. This allows Raspbian which commonly uses 2.28 to work better. I have encountered no issues with this PR. 