### PR TITLE
Add M1 support to build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,7 +103,7 @@ jobs:
         if: steps.cache-natives.outputs.cache-hit != 'true'
         run: |
           chmod +x gradlew
-          ./gradlew buildDarwin64
+          ./gradlew buildDarwin
       - uses: actions/upload-artifact@v2
         with:
           name: mac-natives

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,8 +82,7 @@ jobs:
           name: linux-arm-natives
           path: src/main/resources/natives/*
   mac-natives:
-    if: "false"
-    runs-on: ubuntu-20.04
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
         with:
@@ -100,19 +99,10 @@ jobs:
         if: steps.cache-natives.outputs.cache-hit != 'true'
         with:
           java-version: 15
-      - name: Install darwin compiler
-        if: steps.cache-natives.outputs.cache-hit != 'true'
-        run: |
-          curl -sL https://github.com/natanbc/actions-binaries/releases/download/1/osxcross.tar.gz -o - | tar -xzf -
-          sudo add-apt-repository "deb http://security.ubuntu.com/ubuntu xenial-security main"
-          sudo apt update
-          sudo apt install libssl1.0.0
       - name: Build darwin natives
         if: steps.cache-natives.outputs.cache-hit != 'true'
         run: |
           chmod +x gradlew
-          export PATH="$PATH:$(pwd)/osxcross/bin"
-          export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$(pwd)/osxcross/lib"
           ./gradlew buildDarwin64
       - uses: actions/upload-artifact@v2
         with:
@@ -179,8 +169,7 @@ jobs:
           name: windows-natives
           path: src/main/resources/natives/*
   build:
-    #needs: [linux-x86-natives, linux-arm-natives, mac-natives, freebsd-natives, windows-natives]
-    needs: [linux-x86-natives, linux-arm-natives, freebsd-natives, windows-natives]
+    needs: [linux-x86-natives, linux-arm-natives, mac-natives, freebsd-natives, windows-natives]
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -194,7 +183,6 @@ jobs:
           name: linux-arm-natives
           path: src/main/resources/natives/
       - uses: actions/download-artifact@v2
-        if: "false"
         with:
           name: mac-natives
           path: src/main/resources/natives/

--- a/natives/build.gradle
+++ b/natives/build.gradle
@@ -49,7 +49,6 @@ model {
     binaries {
         all {
             lib library: 'jni', linkage: 'api'
-
             if(toolChain in VisualCpp) {
                 cppCompiler.define "ST_NO_EXCEPTION_HANDLING"
                 cppCompiler.args << '/std:c++17' << "/Ox"

--- a/natives/build.gradle
+++ b/natives/build.gradle
@@ -118,6 +118,5 @@ tasks.withType(LinkSharedLibrary) {
     def newPath = new File(rootProject.projectDir, "src/main/resources/natives/" + targetDirectoryName(target) + "/" + filename).getAbsoluteFile()
     newPath.getParentFile().mkdirs()
     it.linkedFile.set(newPath)
-    println("TARGET: " + target + ", PATH: " + newPath)
     taskForTarget(target).dependsOn it
 }

--- a/natives/build.gradle
+++ b/natives/build.gradle
@@ -114,8 +114,8 @@ tasks.withType(LinkSharedLibrary) {
         def baseName = filename.substring(0, filename.lastIndexOf('.'))
         filename = baseName + "-avx2" + filename.substring(filename.lastIndexOf('.'))
     }
-    def newPath = new File(rootProject.projectDir, "src/main/resources/natives/" + arch + "/" + filename).getAbsoluteFile()
+    def newPath = new File(rootProject.projectDir, "src/main/resources/natives/" + targetDirectoryName(target) + "/" + filename).getAbsoluteFile()
     newPath.getParentFile().mkdirs()
     it.linkedFile.set(newPath)
-    taskForTarget(it.targetPlatform.get()).dependsOn it
+    taskForTarget(target).dependsOn it
 }

--- a/natives/build.gradle
+++ b/natives/build.gradle
@@ -95,12 +95,20 @@ model {
 tasks.withType(LinkSharedLibrary) {
     def flavor = it.linkedFile.asFile.orNull.getParentFile().getName()
     def filename = it.installName.get()
-    def arch = targetDirectoryName(it.targetPlatform.get())
-    if(arch.contains("darwin")) {
-        filename = filename.replace(".so", ".dylib")
+    def target = it.targetPlatform.get()
+    if(isDarwin(target)) {
+        def baseName = filename.substring(0, filename.lastIndexOf('.'))
+        if(isX86_64(target)) {
+            filename += "-x86-64"
+        } else if(isArm64(target)) {
+            filename += "-aarch64"
+        } else {
+            throw new Exception("Unhandled darwin target '" + target + "'")
+        }
+        filename = baseName + ".dylib"
     }
     if(flavor == "avx2") {
-        if(!isX86(it.targetPlatform.get())) {
+        if(!isX86(target)) {
             return
         }
         def baseName = filename.substring(0, filename.lastIndexOf('.'))

--- a/natives/build.gradle
+++ b/natives/build.gradle
@@ -117,5 +117,6 @@ tasks.withType(LinkSharedLibrary) {
     def newPath = new File(rootProject.projectDir, "src/main/resources/natives/" + targetDirectoryName(target) + "/" + filename).getAbsoluteFile()
     newPath.getParentFile().mkdirs()
     it.linkedFile.set(newPath)
+    println("TARGET: " + target + ", PATH: " + newPath)
     taskForTarget(target).dependsOn it
 }

--- a/natives/build.gradle
+++ b/natives/build.gradle
@@ -96,23 +96,24 @@ tasks.withType(LinkSharedLibrary) {
     def flavor = it.linkedFile.asFile.orNull.getParentFile().getName()
     def filename = it.installName.get()
     def target = it.targetPlatform.get()
-    if(isDarwin(target)) {
-        def baseName = filename.substring(0, filename.lastIndexOf('.'))
-        if(isX86_64(target)) {
-            filename += "-x86-64"
-        } else if(isArm64(target)) {
-            filename += "-aarch64"
-        } else {
-            throw new Exception("Unhandled darwin target '" + target + "'")
-        }
-        filename = baseName + ".dylib"
-    }
     if(flavor == "avx2") {
         if(!isX86(target)) {
             return
         }
         def baseName = filename.substring(0, filename.lastIndexOf('.'))
         filename = baseName + "-avx2" + filename.substring(filename.lastIndexOf('.'))
+    } else { // keep darwin avx2 natives with the default name, no need to avoid conflict with arm64
+        if(isDarwin(target)) {
+            def baseName = filename.substring(0, filename.lastIndexOf('.'))
+            if(isX86_64(target)) {
+                baseName += "-x86-64"
+            } else if(isArm64(target)) {
+                baseName += "-aarch64"
+            } else {
+                throw new Exception("Unhandled darwin target '" + target + "'")
+            }
+            filename = baseName + ".dylib"
+        }
     }
     def newPath = new File(rootProject.projectDir, "src/main/resources/natives/" + targetDirectoryName(target) + "/" + filename).getAbsoluteFile()
     newPath.getParentFile().mkdirs()

--- a/natives/toolchains.gradle
+++ b/natives/toolchains.gradle
@@ -1,6 +1,7 @@
 import org.apache.tools.ant.taskdefs.condition.Os
 
 task buildDarwin64 {}
+task buildDarwinAarch64 {}
 task buildFreebsd64 {}
 task buildLinuxGlibc32 {}
 task buildLinuxGlibc64 {}
@@ -12,7 +13,25 @@ task buildWin32 {}
 task buildWin64 {}
 
 task buildDarwin {
-    dependsOn buildDarwin64
+    dependsOn buildDarwin64, buildDarwinAarch64
+
+    def newPath = new File(rootProject.projectDir, "src/main/resources/natives/" + "darwin" + "/")
+
+    def x86FilePath = new File(newPath, 'libtimescale-x86-64.dylib')
+    def aarch64FilePath = new File(newPath, 'libtimescale-aarch64.dylib')
+    def finalFilePath = new File(newPath, 'libtimescale.dylib')
+
+    doLast {
+        def stdout = new ByteArrayOutputStream()
+        exec {
+            commandLine 'lipo', x86FilePath.getAbsoluteFile(), aarch64FilePath.getAbsoluteFile(), '-output', finalFilePath.getAbsoluteFile(), '-create'
+            standardOutput = stdout
+        }
+
+        println "Output: $stdout"
+        x86FilePath.delete()
+        aarch64FilePath.delete()
+    }
 }
 
 task buildFreebsd {
@@ -37,6 +56,7 @@ static def platformName(p) {
 
 def targetDirectory = [
         darwin_x86_64: "darwin",
+        darwin_aarch64: "darwin",
         freebsd_x86_64: "freebsd-x86-64",
         linux_glibc_x86: "linux-x86",
         linux_glibc_x86_64: "linux-x86-64",
@@ -58,6 +78,7 @@ project.ext.targetDirectoryName = { platform ->
 
 def tasksByTarget = [
         darwin_x86_64:       buildDarwin64,
+        darwin_aarch64:      buildDarwinAarch64,
         freebsd_x86_64:      buildFreebsd64,
         linux_glibc_x86:     buildLinuxGlibc32,
         linux_glibc_x86_64:  buildLinuxGlibc64,
@@ -135,6 +156,14 @@ model {
                     args.removeIf { it.startsWith("-Wl,-soname") }
                 }
             }
+            target("darwin_aarch64") {
+                // add flags for m1
+                cCompiler.withArguments { args -> args << '-target arm64-apple-macos11'}
+                cppCompiler.withArguments { args -> args << '-target arm64-apple-macos11'}
+                linker.withArguments { args ->
+                    args.removeIf { it.startsWith("-Wl,-soname") }
+                }
+            }
         }
         glibc(Gcc) {
             target("linux_glibc_arm") {
@@ -195,6 +224,10 @@ model {
     platforms {
         darwin_x86_64 {
             architecture "x86_64"
+            operatingSystem "mac"
+        }
+        darwin_aarch64 {
+            architecture "aarch64"
             operatingSystem "mac"
         }
         freebsd_x86_64 {

--- a/natives/toolchains.gradle
+++ b/natives/toolchains.gradle
@@ -31,7 +31,6 @@ task buildDarwin {
 
         println "Output: $stdout"
         x86FilePath.delete()
-        avx2FilePath.delete()
         aarch64FilePath.delete()
     }
 }

--- a/natives/toolchains.gradle
+++ b/natives/toolchains.gradle
@@ -160,8 +160,8 @@ model {
             }
             target("darwin_aarch64") {
                 // add flags for m1
-                cCompiler.withArguments { args -> args << '-target arm64-apple-macos11'}
-                cppCompiler.withArguments { args -> args << '-target arm64-apple-macos11'}
+                cCompiler.withArguments { args -> args << '-target arm64-apple-macos11' << '-mmacosx-version-min=10.12.6' }
+                cppCompiler.withArguments { args -> args << '-target arm64-apple-macos11' << '-mmacosx-version-min=10.12.6'}
                 linker.withArguments { args ->
                     args.removeIf { it.startsWith("-Wl,-soname") }
                 }

--- a/natives/toolchains.gradle
+++ b/natives/toolchains.gradle
@@ -25,7 +25,7 @@ task buildDarwin {
     doLast {
         def stdout = new ByteArrayOutputStream()
         exec {
-            commandLine 'lipo', avx2FilePath.getAbsoluteFile(), aarch64FilePath.getAbsoluteFile(), '-output', finalFilePath.getAbsoluteFile(), '-create'
+            commandLine 'lipo', x86FilePath.getAbsoluteFile(), aarch64FilePath.getAbsoluteFile(), '-output', finalFilePath.getAbsoluteFile(), '-create'
             standardOutput = stdout
         }
 

--- a/natives/toolchains.gradle
+++ b/natives/toolchains.gradle
@@ -158,11 +158,11 @@ model {
                 }
             }
             target("darwin_aarch64") {
-                // add flags for m1
                 cCompiler.withArguments { args -> args << '-target' << 'arm64-apple-macos11' << '-mmacosx-version-min=10.12.6' }
                 cppCompiler.withArguments { args -> args << '-target' << 'arm64-apple-macos11' << '-mmacosx-version-min=10.12.6'}
                 linker.withArguments { args ->
                     args.removeIf { it.startsWith("-Wl,-soname") }
+                    args << '-target' << 'arm64-apple-macos11'
                 }
             }
         }

--- a/natives/toolchains.gradle
+++ b/natives/toolchains.gradle
@@ -159,8 +159,8 @@ model {
             }
             target("darwin_aarch64") {
                 // add flags for m1
-                cCompiler.withArguments { args -> args << '-target arm64-apple-macos11' << '-mmacosx-version-min=10.12.6' }
-                cppCompiler.withArguments { args -> args << '-target arm64-apple-macos11' << '-mmacosx-version-min=10.12.6'}
+                cCompiler.withArguments { args -> args << '-target' << 'arm64-apple-macos11' << '-mmacosx-version-min=10.12.6' }
+                cppCompiler.withArguments { args -> args << '-target' << 'arm64-apple-macos11' << '-mmacosx-version-min=10.12.6'}
                 linker.withArguments { args ->
                     args.removeIf { it.startsWith("-Wl,-soname") }
                 }

--- a/natives/toolchains.gradle
+++ b/natives/toolchains.gradle
@@ -131,13 +131,9 @@ model {
         visualCpp(VisualCpp)
         clang(Clang) {
             target("darwin_x86_64") {
-                cCompiler.executable 'x86_64-apple-darwin15-clang'
-                cppCompiler.executable 'x86_64-apple-darwin15-clang++-libc++'
-                linker.executable 'x86_64-apple-darwin15-clang++-libc++'
                 linker.withArguments { args ->
                     args.removeIf { it.startsWith("-Wl,-soname") }
                 }
-                staticLibArchiver.executable 'x86_64-apple-darwin15-ar'
             }
         }
         glibc(Gcc) {

--- a/natives/toolchains.gradle
+++ b/natives/toolchains.gradle
@@ -15,21 +15,16 @@ task buildWin64 {}
 task buildDarwin {
     dependsOn buildDarwin64, buildDarwinAarch64
 
-    def newPath = new File(rootProject.projectDir, "src/main/resources/natives/" + "darwin" + "/")
+    def newPath = new File(rootProject.projectDir, "src/main/resources/natives/darwin")
 
     def x86FilePath = new File(newPath, 'libtimescale-x86-64.dylib')
     def aarch64FilePath = new File(newPath, 'libtimescale-aarch64.dylib')
-    def avx2FilePath = new File(newPath, 'libtimescale-avx2.dylib')
     def finalFilePath = new File(newPath, 'libtimescale.dylib')
 
     doLast {
-        def stdout = new ByteArrayOutputStream()
         exec {
             commandLine 'lipo', x86FilePath.getAbsoluteFile(), aarch64FilePath.getAbsoluteFile(), '-output', finalFilePath.getAbsoluteFile(), '-create'
-            standardOutput = stdout
         }
-
-        println "Output: $stdout"
         x86FilePath.delete()
         aarch64FilePath.delete()
     }

--- a/natives/toolchains.gradle
+++ b/natives/toolchains.gradle
@@ -19,17 +19,19 @@ task buildDarwin {
 
     def x86FilePath = new File(newPath, 'libtimescale-x86-64.dylib')
     def aarch64FilePath = new File(newPath, 'libtimescale-aarch64.dylib')
+    def avx2FilePath = new File(newPath, 'libtimescale-avx2.dylib')
     def finalFilePath = new File(newPath, 'libtimescale.dylib')
 
     doLast {
         def stdout = new ByteArrayOutputStream()
         exec {
-            commandLine 'lipo', x86FilePath.getAbsoluteFile(), aarch64FilePath.getAbsoluteFile(), '-output', finalFilePath.getAbsoluteFile(), '-create'
+            commandLine 'lipo', avx2FilePath.getAbsoluteFile(), aarch64FilePath.getAbsoluteFile(), '-output', finalFilePath.getAbsoluteFile(), '-create'
             standardOutput = stdout
         }
 
         println "Output: $stdout"
         x86FilePath.delete()
+        avx2FilePath.delete()
         aarch64FilePath.delete()
     }
 }


### PR DESCRIPTION
Depends on #88, thanks @Walkyst for your work there! 

This adds M1 as a target compilation from x86_x64 mac runner, in addition min deployment target with the default XCode supplied is 10.12.6, as Lavalink will only run on 10.12, re @aikaterna.

Thanks to @aikaterna and @jack1142 for assisting with this PR. 

Some improvements, we could ditch Java 15 and use the built-in Github runner java versions https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md#java but it's not really needed, unless you want me to do that @natanbc 

TODO:

- [x] Solve the native folder for darwin creating several files